### PR TITLE
Bootstrap3 Input Groups & File Fields

### DIFF
--- a/lib/formular/builder.rb
+++ b/lib/formular/builder.rb
@@ -111,7 +111,7 @@ module Formular
     end
 
     private def private_options
-      [:label, :error, :inline, :wrapper, :wrapper_attrs, :label_attrs, :column_attrs, :style, :hint]
+      [:label, :error, :inline, :wrapper, :wrapper_attrs, :label_attrs]
     end
 
     private def private_options_for(options, default_options = private_options)

--- a/lib/formular/control.rb
+++ b/lib/formular/control.rb
@@ -3,7 +3,7 @@ module Formular
   class Builder # i hate that, please, give use namespace Builder
     module Label
       # DISCUSS: pass in content?
-      #A labels for attribute is now optional. 
+      #A labels for attribute is now optional.
       #If you set options[:for] == false it will not be included
       def label(attributes, options) # DISCUSS: should labels be part of a Control or a higher-level widget?
         return "" unless options[:label]

--- a/lib/formular/frontend/bootstrap3.rb
+++ b/lib/formular/frontend/bootstrap3.rb
@@ -146,7 +146,8 @@ module Formular
 
       private
         def control(attributes, options, &block)
-          attributes.merge!(class: ["form-control"])
+          #don't add form-control class to file fields
+          attributes.merge!(class: ["form-control"]) unless attributes[:type] == "file"
           input(attributes, options)
         end
       end #class Input

--- a/test/bootstrap3/horizontal_form_test.rb
+++ b/test/bootstrap3/horizontal_form_test.rb
@@ -8,22 +8,22 @@ class Bootstrap3HorizontalFormTest < Minitest::Spec
   describe "#form style: :horizontal" do
     it { builder.form(style: :horizontal){}.must_eq %{<form class="form-horizontal" />} }
     it { builder.form(style: :horizontal, class: [:bright]){}.must_eq %{<form class="form-horizontal bright" />} }
-    
+
     describe "#input" do
-      it "without Label" do 
+      it "without Label" do
         builder.input(:id, style: :horizontal, column_attrs: { input_class: ["col-sm-offset-2", "col-sm-10"]} ).must_eq %{
 <div class="form-group">
 <div class="col-sm-offset-2 col-sm-10"><input type="text" name="id" id="form_id" class="form-control" value="" /></div>
-</div>} 
+</div>}
       end
-      it do 
+      it do
         builder.input(:id, style: :horizontal, label: "ID", column_attrs: { label_class: ["col-sm-2"], input_class: ["col-sm-10"]} ).must_eq %{
 <div class="form-group">
 <label class="control-label col-sm-2" for="form_id">ID</label>
 <div class="col-sm-10"><input type="text" name="id" id="form_id" class="form-control" value="" /></div>
 </div>}
       end
-      
+
       describe "with errors" do
         it { builder.input(:id, style: :horizontal, label: "ID", error: ["wrong@!"], column_attrs: { label_class: ["col-sm-2"], input_class: ["col-sm-10"]} ).must_eq %{
 <div class="form-group has-error">
@@ -45,20 +45,20 @@ class Bootstrap3HorizontalFormTest < Minitest::Spec
 </div>} }
       end
     end
-    
+
     describe "#textarea" do
-      it "without label" do 
+      it "without label" do
         builder.textarea(:public, style: :horizontal, column_attrs: { input_class: ["col-sm-offset-2", "col-sm-10"]} ).must_eq %{
 <div class="form-group">
 <div class="col-sm-offset-2 col-sm-10"><textarea name="public" id="form_public" class="form-control"></textarea></div>
-</div>} 
+</div>}
       end
-      it do 
+      it do
         builder.textarea(:public, style: :horizontal, label: "Public", column_attrs: { label_class: ["col-sm-2"], input_class: ["col-sm-10"]} ).must_eq %{
 <div class="form-group">
 <label class="control-label col-sm-2" for="form_public">Public</label>
 <div class="col-sm-10"><textarea name="public" id="form_public" class="form-control"></textarea></div>
-</div>} 
+</div>}
       end
 
       describe "with errors" do
@@ -108,7 +108,7 @@ class Bootstrap3HorizontalFormTest < Minitest::Spec
 </div>
 </div>}
       end
-      
+
       describe "with errors" do
         it do
           builder.collection(:public, [[:One, 1],[:Two, 2],[:Three, 3]], selected: [2], type: :select, style: :horizontal, label: "Public", error: ["wrong@!"], column_attrs: { label_class: ["col-sm-2"], input_class: ["col-sm-10"]}).must_eq %{
@@ -125,7 +125,7 @@ class Bootstrap3HorizontalFormTest < Minitest::Spec
 </div>}
         end
       end
-      
+
       describe "with hint" do
         it do
           builder.collection(:public, [[:One, 1],[:Two, 2],[:Three, 3]], selected: [2], type: :select, style: :horizontal, label: "Public", hint: "Handy help text", column_attrs: { label_class: ["col-sm-2"], input_class: ["col-sm-10"]}).must_eq %{
@@ -143,7 +143,7 @@ class Bootstrap3HorizontalFormTest < Minitest::Spec
         end
       end
     end
-    
+
     describe "collection type: :checkbox" do
       it "without label" do
         builder.collection(:public, [[:One, 1],[:Two, 2],[:Three, 3]], type: :checkbox, checked: [2,3], style: :horizontal, column_attrs: { input_class: ["col-sm-offset-2","col-sm-10"]}).must_eq %{
@@ -155,7 +155,7 @@ class Bootstrap3HorizontalFormTest < Minitest::Spec
 </div>
 </div>}
       end
-      
+
       it do
         # TODO: allow merging :class!
         builder.collection(:public, [[:One, 1],[:Two, 2],[:Three, 3]], type: :checkbox, checked: [2,3], style: :horizontal, label: "One!", column_attrs: { label_class: ["col-sm-2"], input_class: ["col-sm-10"]}).must_eq %{
@@ -197,7 +197,7 @@ class Bootstrap3HorizontalFormTest < Minitest::Spec
 </div>}
         end
       end
-      
+
       describe "with hint" do
         it do
           builder.collection(:public, [[:One, 1],[:Two, 2],[:Three, 3]], type: :checkbox, checked: [2,3], style: :horizontal, label: "One!", hint: "Handy help text", column_attrs: { label_class: ["col-sm-2"], input_class: ["col-sm-10"]}).must_eq %{
@@ -226,7 +226,7 @@ class Bootstrap3HorizontalFormTest < Minitest::Spec
         end
       end
     end
-    
+
     describe "collection type: :radio" do
       it "without label" do
         # TODO: allow merging :class!
@@ -239,7 +239,7 @@ class Bootstrap3HorizontalFormTest < Minitest::Spec
 </div>
 </div>}
       end
-      
+
       it do
         # TODO: allow merging :class!
         builder.collection(:public, [[:One, 1],[:Two, 2],[:Three, 3]], type: :radio, checked: [2,3], style: :horizontal, label: "One!", column_attrs: { label_class: ["col-sm-2"], input_class: ["col-sm-10"]}).must_eq %{
@@ -279,7 +279,7 @@ class Bootstrap3HorizontalFormTest < Minitest::Spec
 </div>}
         end
       end
-      
+
       describe "with hint" do
         it do
           builder.collection(:public, [[:One, 1],[:Two, 2],[:Three, 3]], type: :radio, checked: [2,3], style: :horizontal, label: "One!", inline: true, hint: "Handy help text", column_attrs: { label_class: ["col-sm-2"], input_class: ["col-sm-10"]}).must_eq %{

--- a/test/bootstrap3/input_group_test.rb
+++ b/test/bootstrap3/input_group_test.rb
@@ -1,0 +1,131 @@
+require "test_helper"
+require "formular/frontend/bootstrap3"
+
+class Bootstrap3InputGroupTest < Minitest::Spec
+  let (:model) { Comment.new(nil, nil, [Reply.new]) }
+  let (:builder) { Formular::Bootstrap3::Builder.new(model: model) }
+
+  describe "InputGroup" do
+    it "basic content left" do
+      builder.input(:id, input_group: { left: { content: "@" } }).must_eq %{
+<div class="form-group">
+<div class="input-group">
+<span class="input-group-addon">@</span>
+<input type="text" name="id" id="form_id" class="form-control" value="" />
+</div>
+</div>}
+    end
+
+    it "basic content right" do
+      builder.input(:id, input_group: { right: { content: "@" } }).must_eq %{
+<div class="form-group">
+<div class="input-group">
+<input type="text" name="id" id="form_id" class="form-control" value="" />
+<span class="input-group-addon">@</span>
+</div>
+</div>}
+    end
+
+    it "basic content both" do
+      builder.input(:id, input_group: { left: {content: "@@" }, right: { content: "@" } }).must_eq %{
+<div class="form-group">
+<div class="input-group">
+<span class="input-group-addon">@@</span>
+<input type="text" name="id" id="form_id" class="form-control" value="" />
+<span class="input-group-addon">@</span>
+</div>
+</div>}
+    end
+
+    it "with input group wrapper attributes" do
+      builder.input(:id, input_group: { right: { content: "@" }, attrs: { class: ["input-wrapper"], id: "unique", 'data-options': "something good" }}).must_eq %{
+<div class="form-group">
+<div class="input-group input-wrapper" id="unique" data-options="something good">
+<input type="text" name="id" id="form_id" class="form-control" value="" />
+<span class="input-group-addon">@</span>
+</div>
+</div>}
+    end
+
+
+    it "with HTML content" do
+      builder.input(:id, input_group: { right: { content: "<span class='glyphicon glyphicon-tick'></span>" } }).must_eq %{
+<div class="form-group">
+<div class="input-group">
+<input type="text" name="id" id="form_id" class="form-control" value="" />
+<span class="input-group-addon"><span class='glyphicon glyphicon-tick'></span></span>
+</div>
+</div>}
+    end
+
+
+    it "with button as content" do
+      builder.input(:id, input_group: { right: { content: "<button class='btn btn-default' type='button'>Go!</button>", button: true } }).must_eq %{
+<div class="form-group">
+<div class="input-group">
+<input type="text" name="id" id="form_id" class="form-control" value="" />
+<span class="input-group-btn"><button class='btn btn-default' type='button'>Go!</button></span>
+</div>
+</div>}
+    end
+
+    it "with control as content" do
+      builder.input(:id, input_group: { right: { content: builder.radio(:public, value: 1, inline: true) } }).must_eq %{
+<div class="form-group">
+<div class="input-group">
+<input type="text" name="id" id="form_id" class="form-control" value="" />
+<span class="input-group-addon"><input type="radio" value="1" name="public" id="form_public_1" /></span>
+</div>
+</div>}
+    end
+
+
+    it "with error" do
+      builder.input(:id, input_group: { right: { content: "@" } }, error: ["wrong@!"]).must_eq %{
+<div class="form-group has-error">
+<div class="input-group">
+<input type="text" name="id" id="form_id" class="form-control" value="" />
+<span class="input-group-addon">@</span>
+</div>
+<span class="help-block">["wrong@!"]</span>
+</div>}
+    end
+
+    it "with hint" do
+      builder.input(:id, input_group: { right: { content: "@" } }, hint: "Handy help text").must_eq %{
+<div class="form-group">
+<div class="input-group">
+<input type="text" name="id" id="form_id" class="form-control" value="" />
+<span class="input-group-addon">@</span>
+</div>
+<span class="help-block">Handy help text</span>
+</div>}
+    end
+
+
+    it "with label" do
+      builder.input(:id, input_group: { right: { content: "@" } } , label: "ID").must_eq %{
+<div class="form-group">
+<label class="control-label" for="form_id">ID</label>
+<div class="input-group">
+<input type="text" name="id" id="form_id" class="form-control" value="" />
+<span class="input-group-addon">@</span>
+</div>
+</div>}
+    end
+
+    it "with horizontal form" do
+      builder.input(:id, style: :horizontal, label: "ID", column_attrs: { label_class: ["col-sm-2"], input_class: ["col-sm-10"]}, input_group: { right: { content: "@" } }).must_eq %{
+<div class="form-group">
+<label class="control-label col-sm-2" for="form_id">ID</label>
+<div class="col-sm-10">
+<div class="input-group">
+<input type="text" name="id" id="form_id" class="form-control" value="" />
+<span class="input-group-addon">@</span>
+</div>
+</div>
+</div>}
+    end
+  end
+
+end

--- a/test/bootstrap3_test.rb
+++ b/test/bootstrap3_test.rb
@@ -19,7 +19,7 @@ class Bootstrap3Test < Minitest::Spec
 <input type="text" name="id" id="form_id" class="form-control" value="" />
 <span class="help-block">Handy help text</span>
 </div>} }
-    
+
     # no options.
     it { builder.input(:id).must_eq %{
 <div class="form-group">
@@ -92,18 +92,18 @@ class Bootstrap3Test < Minitest::Spec
 </div>} }
 
       describe "with label" do
-        it do 
+        it do
           builder.input(:id, label: "Id").must_eq %{
 <div class="form-group has-error">
 <label class="control-label" for="form_id">Id</label>
 <input type="text" name="id" id="form_id" class="form-control" value="" />
 <span class="help-block">[\"wrong!\"]</span>
-</div>} 
+</div>}
         end
       end
-      
+
       describe "with hint" do
-        it do 
+        it do
           builder.input(:id, hint: "Handy help text").must_eq %{
 <div class="form-group has-error">
 <input type="text" name="id" id="form_id" class="form-control" value="" />
@@ -127,13 +127,13 @@ class Bootstrap3Test < Minitest::Spec
       end
 
 
-      it "with label & has error" do 
+      it "with label & has error" do
         builder.input(:id, label: "Id", wrapper: false, error: ["wrong!"]).must_eq %{
 <label class="control-label" for="form_id">Id</label>
 <input type="text" name="id" id="form_id" class="form-control" value="" />
 <span class="help-block">[\"wrong!\"]</span>}
       end
-          
+
       it "with hint" do
          builder.input(:id, hint: 'Handy help text', wrapper: false).must_eq %{
 <input type="text" name="id" id="form_id" class="form-control" value="" />
@@ -146,14 +146,14 @@ class Bootstrap3Test < Minitest::Spec
     it "wrapper: false" do
       builder.textarea(:public, rows: 3, wrapper: false).must_eq %{<textarea rows="3" name="public" id="form_public" class="form-control"></textarea>}
     end
-    
+
     it do
       builder.textarea(:public, rows: 3).must_eq %{
 <div class="form-group">
 <textarea rows="3" name="public" id="form_public" class="form-control"></textarea>
 </div>}
     end
-    
+
     it "with label" do
       builder.textarea(:public, rows: 3, label: "Public").must_eq %{
 <div class="form-group">
@@ -369,7 +369,7 @@ Public?
 </div>}
       end
     end
-    
+
     it do
       builder.collection(:public, [[:One, 1],[:Two, 2],[:Three, 3]], selected: [2], label: "One!", type: :select).must_eq %{
 <div class="form-group">

--- a/test/bootstrap3_test.rb
+++ b/test/bootstrap3_test.rb
@@ -6,6 +6,15 @@ class Bootstrap3Test < Minitest::Spec
   let (:builder) { Formular::Bootstrap3::Builder.new(model: model) }
 
   describe "#input" do
+
+    # with file fields.
+    it "type: 'file' shouldn't have form-control class" do
+      builder.input(:id, type: "file").must_eq %{
+<div class="form-group">
+<input type="file" name="id" id="form_id" value="" />
+</div>}
+  end
+
     # with label.
     it { builder.input(:id, label: "Id").must_eq %{
 <div class="form-group">

--- a/test/formular_test.rb
+++ b/test/formular_test.rb
@@ -13,6 +13,12 @@ class FormularTest < Minitest::Spec
     end
   end
 
+  describe ":type" do
+    it do
+      builder.input(:id, type: "file").must_eq %{<input type="file" name="id" id="form_id" value="" />}
+    end
+  end
+
 
   describe ":id" do
     it { builder.input(:id).must_eq %{<input type="text" name="id" id="form_id" value="" />} }


### PR DESCRIPTION
1) added support for bootstrap input groups
2) removed bootstrap options from builder
3) cleaned up whitespace
4) added formular test for type attribute
5) ensure that bootstrap3 doesn't add form-control class to file inputs